### PR TITLE
Spin button disabled

### DIFF
--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -110,7 +110,7 @@ const RoulettePage: NextPage<{ params: { id: string } }> = (context) => {
             onFinish={handleFinish}
           />
         </Card>
-        <Button size="large" type="primary" block onClick={handleSpin}disabled={isSpinning}>
+        <Button size="large" type="primary" block onClick={handleSpin} disabled={isSpinning || (players?.length ?? 0) < 2}>
           {t('spin')}
         </Button>
         <LastDonatorsCard editable roulette={roulette?._id} />

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -13,7 +13,7 @@ import { getRandomIndexWithProbabilities } from '@utils/helpers'
 import { Button, Card, Empty } from 'antd'
 import { NextPage } from 'next'
 import Image from 'next/image'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styles from './page.module.css'
 
@@ -54,10 +54,14 @@ const RoulettePage: NextPage<{ params: { id: string } }> = (context) => {
     [editRoulette, roulette]
   )
 
+  const [isSpinning, setIsSpinning] = useState(false)
+
   const handleSpin = useCallback(() => {
     if (!players) {
       return
     }
+
+    setIsSpinning(true)
 
     const index = roulette?.target
       ? players.findIndex(({ _id }) => _id === roulette.target!._id)
@@ -106,7 +110,7 @@ const RoulettePage: NextPage<{ params: { id: string } }> = (context) => {
             onFinish={handleFinish}
           />
         </Card>
-        <Button size="large" type="primary" block onClick={handleSpin}>
+        <Button size="large" type="primary" block onClick={handleSpin}disabled={isSpinning}>
           {t('spin')}
         </Button>
         <LastDonatorsCard editable roulette={roulette?._id} />

--- a/components/Lists/LastDonatorsList/index.tsx
+++ b/components/Lists/LastDonatorsList/index.tsx
@@ -66,7 +66,7 @@ export const LastDonatorsListItem: React.FC<LastDonatorsListItemProps> = ({
     <List.Item
       onClick={() => {
         handleClick()
-        // handleRegister()
+        handleRegister()
       }}
     >
       <PlayersListItemMeta player={donator} />

--- a/components/Lists/LastDonatorsList/index.tsx
+++ b/components/Lists/LastDonatorsList/index.tsx
@@ -66,7 +66,7 @@ export const LastDonatorsListItem: React.FC<LastDonatorsListItemProps> = ({
     <List.Item
       onClick={() => {
         handleClick()
-        handleRegister()
+        // handleRegister()
       }}
     >
       <PlayersListItemMeta player={donator} />


### PR DESCRIPTION
## Overview

https://app.asana.com/0/1208484960724226/1208484956724467/f

### Changes

- Updated "Spin" button to be enabled only when there are two or more players
- Disabled the button while the spin is active (isSpinning state)

### 🛠️ Testing

- [ ] Verify the "Spin" button is disabled when there is less than two players
- [ ] Check that the button becomes enabled once two or more players are added
- [ ] Ensure the button remains disabled during an ongoing spin

### 📋 Checklist

- [ ] Self-review
- [ ] Ensure all tests pass
- [ ] Code meets project guidelines (eslint & prettier)
- [ ] No breaking changes
