### PR TITLE
remove button on roulettes page

### DIFF
--- a/components/Cards/DonatorsCard/index.tsx
+++ b/components/Cards/DonatorsCard/index.tsx
@@ -2,7 +2,7 @@ import { DontatorsList } from '@components/Lists/DonatorsList'
 import { useEditPlayersMutation, useGetPlayersQuery } from '@modules/api/player'
 import { useGetRouletteQuery } from '@modules/api/roulette'
 import { IRoulette } from '@modules/models/Roulette'
-import { Button, Card, Flex, message, Modal } from 'antd'
+import { Button, Card, Flex, Modal, message } from 'antd'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -61,9 +61,11 @@ const Title: React.FC<DonatorsCardProps> = ({ roulette: rouletteId }) => {
         {t('donators')} - {donators?.length ?? 0}
       </span>
       <span>
-        <Button type="primary" onClick={handleRegisterAll}>
-          {t('register-all')}
-        </Button>
+        {(!!rouletteId) && (
+          <Button type="primary" onClick={handleRegisterAll}>
+            {t('register-all')}
+          </Button>
+        )}
       </span>
     </Flex>
   )


### PR DESCRIPTION
[## Overview

https://app.asana.com/0/1208484960724226/1208586380221456/f

This pull request adds logic to display the "Register All" button based on the presence of rouletteId in the page URL and for pages that belong to the admin.

### Changes

- The "Register All" button is displayed if rouletteId is present in the URL or if the user is on the admin page.
- In all other cases, the button is hidden.

### 🛠️ Testing

- [ ] Ensure the "Register All" button appears when rouletteId is present in the URL.
- [ ] Verify that the button appears on the admin page.
- [ ] Make sure the button does not appear on other pages.
- [ ] Check that the button works correctly when clicked (if it is available).

### 📋 Checklist

- [ ] Self-review
- [ ] ~~Ensure all tests pass~~
- [ ] Code meets project guidelines (eslint & prettier)
- [ ] No breaking changes
